### PR TITLE
increased font size and switched to text area

### DIFF
--- a/src/components/TypingTest.tsx
+++ b/src/components/TypingTest.tsx
@@ -12,26 +12,6 @@ export default function TypingTest() {
     const [accuracy, setAccuracy] = useState<number>(0);
     const [wpm, setWpm] = useState(0);
     const [isSubmitted, setIsSubmitted] = useState(false);
-    const [fontSize, setFontSize] = useState<number>(4);
-
-    useEffect(() => {
-        // Calculate initial font size based on screen width
-        const calculateFontSize = () => {
-            const screenWidth = window.innerWidth;
-            const baseFontSize = 2; // Base font size (2xl)
-            const scaleFactor = screenWidth / 1440;
-            const calculatedFontSize = baseFontSize * scaleFactor;
-            setFontSize(calculatedFontSize);
-        };
-
-        
-        calculateFontSize();
-        window.addEventListener('resize', calculateFontSize);
-
-        return () => {
-            window.removeEventListener('resize', calculateFontSize);
-        };
-    }, []);
 
     useEffect(() => {
         if (isStarted) {
@@ -86,10 +66,10 @@ export default function TypingTest() {
             return <span key={index}>{letter}</span>;
         } else if (letter === enteredLetter) {
             // Correctly entered letter
-            return <span key={index} className="text-green-500">{letter}</span>;
+            return <span key={index} className="text-green-500 md:text-2xl">{letter}</span>;
         } else {
             // Incorrectly entered letter
-            return <span key={index} className="text-red-500">{letter}</span>;
+            return <span key={index} className="text-red-500 md:text-2xl">{letter}</span>;
         }
     };
 
@@ -101,13 +81,13 @@ export default function TypingTest() {
         <>
             <section className="p-2 flex flex-col gap-3">
                 <Timer time={timer} />
-                <p className="p-2 border rounded" style={{ fontSize: `${fontSize}rem` }}>
+                <p className="p-2 border rounded md:text-2xl">
                     {text.split('').map((_, index) => renderLetter(index))}
                 </p>
                 <textarea
                     disabled={!isStarted}
                     onChange={handleInputChange}
-                    className="p-2 rounded border outline-none text-lg"
+                    className="p-2 rounded border outline-none text-lg md:text-2xl"
                     title="Text area"
                 />
 

--- a/src/components/TypingTest.tsx
+++ b/src/components/TypingTest.tsx
@@ -81,15 +81,14 @@ export default function TypingTest() {
         <>
             <section className="p-2 flex flex-col gap-3">
                 <Timer time={timer} />
-                <p className="p-2 border rounded text-lg font-medium">
+                <p className="p-2 border rounded text-4xl font-medium">
                     {text.split('').map((_, index) => renderLetter(index))}
                 </p>
-                <input
+                <textarea
                     disabled={!isStarted}
                     onChange={handleInputChange}
-                    className="p-2 rounded border outline-none"
-                    title="Text field"
-                    type="text"
+                    className="p-2 rounded border outline-none text-lg"
+                    title="Text area"
                 />
 
                 <button

--- a/src/components/TypingTest.tsx
+++ b/src/components/TypingTest.tsx
@@ -12,6 +12,26 @@ export default function TypingTest() {
     const [accuracy, setAccuracy] = useState<number>(0);
     const [wpm, setWpm] = useState(0);
     const [isSubmitted, setIsSubmitted] = useState(false);
+    const [fontSize, setFontSize] = useState<number>(4);
+
+    useEffect(() => {
+        // Calculate initial font size based on screen width
+        const calculateFontSize = () => {
+            const screenWidth = window.innerWidth;
+            const baseFontSize = 2; // Base font size (2xl)
+            const scaleFactor = screenWidth / 1440;
+            const calculatedFontSize = baseFontSize * scaleFactor;
+            setFontSize(calculatedFontSize);
+        };
+
+        
+        calculateFontSize();
+        window.addEventListener('resize', calculateFontSize);
+
+        return () => {
+            window.removeEventListener('resize', calculateFontSize);
+        };
+    }, []);
 
     useEffect(() => {
         if (isStarted) {
@@ -81,7 +101,7 @@ export default function TypingTest() {
         <>
             <section className="p-2 flex flex-col gap-3">
                 <Timer time={timer} />
-                <p className="p-2 border rounded text-4xl font-medium">
+                <p className="p-2 border rounded" style={{ fontSize: `${fontSize}rem` }}>
                     {text.split('').map((_, index) => renderLetter(index))}
                 </p>
                 <textarea

--- a/src/components/TypingTest.tsx
+++ b/src/components/TypingTest.tsx
@@ -37,7 +37,7 @@ export default function TypingTest() {
         }
     }, [text]);
 
-    const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
         setUserInput(e.target.value);
     };
 


### PR DESCRIPTION
I increased the font size of the word prompts from 'text-large' to 'text-4xl', and switched from using an input field for user input to a text area. Closes Issue #10.

Before:
![image](https://github.com/ashsajal1/typing-app/assets/113255492/28597c05-9457-4c06-9c01-2d3875882185)

After:
![image](https://github.com/ashsajal1/typing-app/assets/113255492/a9ba4aa0-9094-41c1-96f9-d86725916f28)

